### PR TITLE
Initial fullscreen view

### DIFF
--- a/PexelsClient.xcodeproj/project.pbxproj
+++ b/PexelsClient.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D8A2D1182E9A5BE50054A67B /* PhotoFullscreenFeature in Frameworks */ = {isa = PBXBuildFile; productRef = D8A2D1172E9A5BE50054A67B /* PhotoFullscreenFeature */; };
 		D8D142DC2E96208300501AC0 /* PhotosListFeature in Frameworks */ = {isa = PBXBuildFile; productRef = D8D142DB2E96208300501AC0 /* PhotosListFeature */; };
 /* End PBXBuildFile section */
 
@@ -48,6 +49,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8D142DC2E96208300501AC0 /* PhotosListFeature in Frameworks */,
+				D8A2D1182E9A5BE50054A67B /* PhotoFullscreenFeature in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,6 +118,7 @@
 			name = PexelsClient;
 			packageProductDependencies = (
 				D8D142DB2E96208300501AC0 /* PhotosListFeature */,
+				D8A2D1172E9A5BE50054A67B /* PhotoFullscreenFeature */,
 			);
 			productName = PexelsClient;
 			productReference = D8D142992E95FA6900501AC0 /* PexelsClient.app */;
@@ -574,6 +577,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D8A2D1172E9A5BE50054A67B /* PhotoFullscreenFeature */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PhotoFullscreenFeature;
+		};
 		D8D142DB2E96208300501AC0 /* PhotosListFeature */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PhotosListFeature;

--- a/PexelsClient/PexelsClientApp.swift
+++ b/PexelsClient/PexelsClientApp.swift
@@ -1,4 +1,5 @@
 import API
+import PhotoFullscreenFeature
 import PhotosListFeature
 import SwiftUI
 
@@ -7,6 +8,11 @@ struct PexelsClientApp: App {
     var body: some Scene {
         WindowGroup {
             PhotosListView(viewModel: .init(api: .live))
+
+            // To run the app straight into the PhotoFullscreenView, use this:
+//            @Namespace var namespace
+//            @State var isPresented = true
+//            PhotoFullscreenView(viewModel: .init(photo: .dummyLandscape1), namespace: namespace, isPresented: $isPresented)
         }
     }
 }

--- a/PexelsClientModules/Package.swift
+++ b/PexelsClientModules/Package.swift
@@ -4,11 +4,13 @@ import PackageDescription
 
 let package = Package(
     name: "PexelsClientModules",
-    platforms: [.iOS(.v17)],
+    platforms: [.iOS("17.6")],
     products: [
         .library(name: "API", targets: ["API"]),
         .library(name: "Extensions", targets: ["Extensions"]),
+        .library(name: "PhotoFullscreenFeature", targets: ["PhotoFullscreenFeature"]),
         .library(name: "PhotosListFeature", targets: ["PhotosListFeature"]),
+        .library(name: "UI", targets: ["UI"]),
     ],
     targets: [
         .target(
@@ -18,10 +20,26 @@ let package = Package(
             name: "Extensions"
         ),
         .target(
+            name: "PhotoFullscreenFeature",
+            dependencies: [
+                "API",
+                "Extensions",
+                "UI"
+            ]
+        ),
+        .target(
             name: "PhotosListFeature",
             dependencies: [
                 "API",
-                "Extensions"
+                "Extensions",
+                "PhotoFullscreenFeature",
+                "UI"
+            ]
+        ),
+        .target(
+            name: "UI",
+            dependencies: [
+                "Extensions",
             ]
         ),
         .testTarget(
@@ -35,5 +53,6 @@ let package = Package(
                 "PhotosListFeature"
             ]
         ),
+
     ]
 )

--- a/PexelsClientModules/Sources/API/APIStubs.swift
+++ b/PexelsClientModules/Sources/API/APIStubs.swift
@@ -15,10 +15,10 @@ public extension APIClient {
     static var invalidPhotoURL: APIClient {
         .init(
             fetchPhotos: { _, _ in
-                [.init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://im"), avgColor: "#77220B")]
+                [.dummyInvalidURL]
             },
             searchPhotos: { _, _, _ in
-                [.init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://im"), avgColor: "#77220B")]
+                [.dummyInvalidURL]
             }
         )
     }
@@ -37,10 +37,10 @@ public extension APIClient {
     static var one: APIClient {
         .init(
             fetchPhotos: { _, _ in
-                [.init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#77220B")]
+                [.dummyLandscape1]
             },
             searchPhotos: { _, _, _ in
-                [.init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#77220B")]
+                [.dummyLandscape1]
             }
         )
     }
@@ -48,25 +48,55 @@ public extension APIClient {
     static var dummy: APIClient {
         .init(
             fetchPhotos: { _, _ in
-                try? await Task.sleep(nanoseconds: 1_000_000_000) // 1.0s
+//                try? await Task.sleep(nanoseconds: 1_000_000_000) // 1.0s
                 return [
-                    .init(id: 581299, width: 3432, height: 5152, photographer: "Aden Ardenrich", src: .init(medium: "https://images.pexels.com/photos/581299/pexels-photo-581299.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#3F3325"),
-                    .init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#77220B"),
-                    .init(id: 3408353, width: 4160, height: 6240, photographer: "Tomáš Malík", src: .init(medium: "https://images.pexels.com/photos/3408353/pexels-photo-3408353.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#757F8A"),
-                    .init(id: 601174, width: 2415, height: 2415, photographer: "Tirachard Kumtanom", src: .init(medium: "https://images.pexels.com/photos/601174/pexels-photo-601174.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#7E86A8"),
-                    .init(id: 210547, width: 4928, height: 3280, photographer: "Pixabay", src: .init(medium: "https://images.pexels.com/photos/210547/pexels-photo-210547.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#9B755B")
+                    .dummyPortrait1,
+                    .dummyLandscape1,
+                    .dummyPortrait2,
+                    .dummySquare,
+                    .dummyLandscape2
                 ].shuffled()
             }, searchPhotos: { _, _, _ in
-                try? await Task.sleep(nanoseconds: 1_000_000_000) // 1.0s
+//                try? await Task.sleep(nanoseconds: 1_000_000_000) // 1.0s
                 return [
-                    .init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#77220B"),
-                    .init(id: 581299, width: 3432, height: 5152, photographer: "Aden Ardenrich", src: .init(medium: "https://images.pexels.com/photos/581299/pexels-photo-581299.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#3F3325"),
-                    .init(id: 3408353, width: 4160, height: 6240, photographer: "Tomáš Malík", src: .init(medium: "https://images.pexels.com/photos/3408353/pexels-photo-3408353.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#757F8A"),
-                    .init(id: 601174, width: 2415, height: 2415, photographer: "Tirachard Kumtanom", src: .init(medium: "https://images.pexels.com/photos/601174/pexels-photo-601174.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#7E86A8"),
-                    .init(id: 210547, width: 4928, height: 3280, photographer: "Pixabay", src: .init(medium: "https://images.pexels.com/photos/210547/pexels-photo-210547.jpeg?auto=compress&cs=tinysrgb&h=130"), avgColor: "#9B755B")
+                    .dummyLandscape1,
+                    .dummyPortrait1,
+                    .dummyPortrait2,
+                    .dummySquare,
+                    .dummyLandscape2
                 ].shuffled()
             }
         )
+    }
+}
+
+public extension PexelsPhoto {
+    static var dummyLandscape1: PexelsPhoto {
+        .init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg?auto=compress&cs=tinysrgb&h=130", original: "https://images.pexels.com/photos/96420/pexels-photo-96420.jpeg"), avgColor: "#77220B")
+    }
+
+    static var dummyLandscape2: PexelsPhoto {
+        .init(id: 210547, width: 4928, height: 3280, photographer: "Pixabay", src: .init(medium: "https://images.pexels.com/photos/210547/pexels-photo-210547.jpeg?auto=compress&cs=tinysrgb&h=130", original: "https://images.pexels.com/photos/210547/pexels-photo-210547.jpeg"), avgColor: "#9B755B")
+    }
+
+    static var dummyPortrait1: PexelsPhoto {
+        .init(id: 581299, width: 3432, height: 5152, photographer: "Aden Ardenrich", src: .init(medium: "https://images.pexels.com/photos/581299/pexels-photo-581299.jpeg?auto=compress&cs=tinysrgb&h=130", original: "https://images.pexels.com/photos/581299/pexels-photo-581299.jpeg"), avgColor: "#3F3325")
+    }
+
+    static var dummyPortrait2: PexelsPhoto {
+        .init(id: 3408353, width: 4160, height: 6240, photographer: "Tomáš Malík", src: .init(medium: "https://images.pexels.com/photos/3408353/pexels-photo-3408353.jpeg?auto=compress&cs=tinysrgb&h=130", original: "https://images.pexels.com/photos/3408353/pexels-photo-3408353.jpeg"), avgColor: "#757F8A")
+    }
+
+    static var dummySquare: PexelsPhoto {
+        .init(id: 601174, width: 2415, height: 2415, photographer: "Tirachard Kumtanom", src: .init(medium: "https://images.pexels.com/photos/601174/pexels-photo-601174.jpeg?auto=compress&cs=tinysrgb&h=130", original: "https://images.pexels.com/photos/601174/pexels-photo-601174.jpeg"), avgColor: "#7E86A8")
+    }
+
+    static var dummyInvalidURL: PexelsPhoto {
+        .init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://im", original: ""), avgColor: "#77220B")
+    }
+
+    static var dummyWrongURL: PexelsPhoto {
+        .init(id: 96420, width: 4896, height: 3264, photographer: "Francesco Ungaro", src: .init(medium: "https://jsonplaceholder.typicode.com/todos/1", original: "https://jsonplaceholder.typicode.com/todos/1"), avgColor: "#77220B")
     }
 }
 

--- a/PexelsClientModules/Sources/API/Models.swift
+++ b/PexelsClientModules/Sources/API/Models.swift
@@ -19,4 +19,5 @@ public struct PexelsPhoto: Identifiable, Decodable, Equatable, Sendable {
 
 public struct PhotoSrc: Decodable, Equatable, Sendable {
     public let medium: String
+    public let original: String
 }

--- a/PexelsClientModules/Sources/PhotoFullscreenFeature/PhotoFullscreenView.swift
+++ b/PexelsClientModules/Sources/PhotoFullscreenFeature/PhotoFullscreenView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import UI
+
+public struct PhotoFullscreenView: View {
+    @ObservedObject var viewModel: PhotoFullscreenViewModel
+    var namespace: Namespace.ID
+    @Binding var isPresented: Bool
+
+    @State private var showInfo = false
+
+    public init(viewModel: PhotoFullscreenViewModel, namespace: Namespace.ID, isPresented: Binding<Bool>) {
+        self.viewModel = viewModel
+        self.namespace = namespace
+        self._isPresented = isPresented
+    }
+
+    public var body: some View {
+        ZStack {
+            
+            Rectangle()
+                .foregroundStyle(.background)
+                .ignoresSafeArea()
+
+            if let placeholder = viewModel.placeholder {
+                    placeholder
+                        .resizable()
+                        .scaledToFit()
+                        .opacity(viewModel.image == nil ? 1 : 0)
+                        .frame(maxWidth: .infinity)
+                        .matchedGeometryEffect(id: viewModel.photo.id, in: namespace)
+            }
+                if let image = viewModel.image {
+                    GeometryReader { geo in
+                        ZoomableImageView(
+                            image: image,
+                            size: geo.size
+                        )
+                        .ignoresSafeArea()
+                    }
+                } else if let error = viewModel.error {
+                    PlaceholderView(colorHex: viewModel.photo.avgColor, status: .error(error))
+                        .frame(maxWidth: .infinity)
+                        .aspectRatio(CGFloat(viewModel.photo.width) / CGFloat(viewModel.photo.height), contentMode: .fit)
+                } else if viewModel.placeholder != nil {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                } else {
+                    PlaceholderView(colorHex: viewModel.photo.avgColor, status: .loading)
+                        .frame(maxWidth: .infinity)
+                        .aspectRatio(CGFloat(viewModel.photo.width) / CGFloat(viewModel.photo.height), contentMode: .fit)
+                }
+            
+            // Custom toolbar
+            VStack {
+                HStack {
+                    Button(action: {
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                            isPresented = false
+                        }
+                    }) {
+
+                        ZStack {
+                            Circle()
+                                .frame(width: 40, height: 40)
+                                .foregroundStyle(.clear)
+                            Image(systemName: "chevron.left")
+                                .resizable( )
+                                .aspectRatio(contentMode: .fit)
+                                .frame(height: 15)
+                                .foregroundStyle(.foreground)
+                        }
+                    }
+                    .optionalGlassEffect()
+                    .padding(20)
+                    Spacer()
+                    Button(action: {
+                        showInfo.toggle()
+                    }) {
+                        ZStack {
+                            Circle()
+                                .frame(width: 40, height: 40)
+                                .foregroundStyle(.clear)
+                            Image(systemName: "info")
+                                .resizable( )
+                                .aspectRatio(contentMode: .fit)
+                                .frame(height: 15)
+                                .foregroundStyle(.foreground)
+                        }
+                    }
+                    .optionalGlassEffect()
+                    .padding()
+                }
+                Spacer()
+            }
+
+            // Photo info overlay
+            if showInfo {
+                Color.black.opacity(0.8)
+                    .edgesIgnoringSafeArea(.all)
+                VStack {
+                    Text("Photo Information")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .padding()
+                    Text("Photographer: \(viewModel.photo.photographer)")
+                        .foregroundColor(.white)
+                    Link("View Profile", destination: URL(string: "https://www.google.com")!)
+                        .foregroundColor(.blue)
+                        .padding()
+                    Button("Close") {
+                        showInfo = false
+                    }
+                    .padding()
+                    .background(Color.white)
+                    .foregroundColor(.black)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .padding()
+                .background(Color.black.opacity(0.9))
+                .cornerRadius(10)
+            }
+        }
+    }
+}
+
+// Preview
+#Preview {
+    @Previewable @Namespace var namespace
+    @Previewable @State var isPresented = true
+    var image: Image {
+        Color.red
+            .frame(width: 4896, height: 3264)
+            .asImage()
+    }
+    PhotoFullscreenView(viewModel: .init(photo: .dummyWrongURL, placeholder: image), namespace: namespace, isPresented: $isPresented)
+}
+
+extension View {
+    @ViewBuilder func optionalGlassEffect() -> some View {
+        if #available(iOS 26, *) {
+            glassEffect(.clear.tint(.gray.opacity(0.3)))
+        } else {
+            self
+        }
+    }
+}
+
+public extension View {
+    func asImage() -> Image {
+        let renderer = ImageRenderer(content: self)
+        guard let image = renderer.uiImage else { return Image(systemName: "xmark") }
+        return Image(uiImage: image)
+    }
+}

--- a/PexelsClientModules/Sources/PhotoFullscreenFeature/PhotoFullscreenViewModel.swift
+++ b/PexelsClientModules/Sources/PhotoFullscreenFeature/PhotoFullscreenViewModel.swift
@@ -1,0 +1,39 @@
+import API
+import SwiftUI
+
+@MainActor
+public class PhotoFullscreenViewModel: ObservableObject {
+    @Published var image: UIImage?
+    @Published var error: String?
+    @Published var photo: PexelsPhoto
+    @Published var placeholder: Image?
+
+    public init(photo: PexelsPhoto, placeholder: Image? = nil) {
+        self.photo = photo
+        self.placeholder = placeholder
+
+        Task {
+            await loadImage()
+        }
+    }
+
+    private func loadImage() async {
+        guard let url = URL(string: photo.src.original) else {
+            error = "Invalid URL"
+            return
+        }
+
+        do {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            let data = try await URLSession.shared.data(from: url)
+            if let image = UIImage(data: data.0) {
+                self.image = image
+                error = nil
+            } else {
+                error = "No image"
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/PexelsClientModules/Sources/PhotosListFeature/PhotosListView.swift
+++ b/PexelsClientModules/Sources/PhotosListFeature/PhotosListView.swift
@@ -1,9 +1,15 @@
 import API
-import Extensions
+import PhotoFullscreenFeature
 import SwiftUI
+import UI
 
 public struct PhotosListView: View {
     @ObservedObject var viewModel: PhotoViewModel
+
+    @Namespace private var photoNamespace
+    @State private var isFullscreen = false
+    @State private var selectedImage: Image?
+    @State private var selectedPhoto: PexelsPhoto?
 
     public init(viewModel: PhotoViewModel) {
         self.viewModel = viewModel
@@ -14,108 +20,96 @@ public struct PhotosListView: View {
     }
 
     public var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack {
-                    if let error = viewModel.error {
-                        Text("Something went wrong. Please check your internet connection or try again later.")
-                            .padding()
-                            .background(.red.opacity(0.2))
-                            .cornerRadius(20)
+        ZStack {
+            NavigationStack {
+                ScrollView {
+                    VStack {
+                        errorBanner
+                        
+                        Text("Photos provided by Pexels")
+                            .font(.caption)
+                        
+                        photoGrid
+                    }
+                }
+                .refreshable(action: viewModel.didRefresh)
+                .searchable(text: $viewModel.query, prompt: "Search photos...")
+            }
+
+            if isFullscreen, let selectedPhoto, let selectedImage {
+                PhotoFullscreenView(viewModel: .init(photo: selectedPhoto, placeholder: selectedImage), namespace: photoNamespace, isPresented: $isFullscreen)
+                    .transition(.opacity)
+                    .zIndex(1)
+            }
+
+        }
+
+    }
+
+    var photoGrid: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(viewModel.photos) { photo in
+                AsyncImage(url: .init(string: photo.src.medium)) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                            .frame(maxWidth: .infinity)
+                            .clipped()
+                            .matchedGeometryEffect(id: photo.id, in: photoNamespace)
+                            .onTapGesture {
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+                                    selectedPhoto = photo
+                                    selectedImage = image
+                                    isFullscreen = true
+                                }
+                            }
+                    case .failure(let error):
+                        EmptyView()
 #if DEBUG
-                        Text("Error: \(error)")
+                        PlaceholderView(colorHex: photo.avgColor, status: .error(error.localizedDescription))
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
+#endif
+                    case .empty:
+                        PlaceholderView(colorHex: photo.avgColor, status: .loading)
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
+                    @unknown default:
+                        EmptyView()
+#if DEBUG
+                        PlaceholderView(colorHex: photo.avgColor, status: .error("default"))
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
 #endif
                     }
-                    Text("Photos provided by Pexels")
-                        .font(.caption)
-                    LazyVGrid(columns: columns, spacing: 10) {
-                        ForEach(viewModel.photos) { photo in
-                            AsyncImage(url: .init(string: photo.src.medium)) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
-                                        .resizable()
-                                        .scaledToFill()
-                                        .frame(maxWidth: .infinity)
-                                        .clipped()
-                                case .failure(let error):
-                                    EmptyView()
-#if DEBUG
-                                    PlaceholderView(colorHex: photo.avgColor, status: .error(error.localizedDescription))
-                                        .frame(maxWidth: .infinity)
-                                        .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
-#endif
-                                case .empty:
-                                    PlaceholderView(colorHex: photo.avgColor, status: .loading)
-                                        .frame(maxWidth: .infinity)
-                                        .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
-                                @unknown default:
-                                    EmptyView()
-#if DEBUG
-                                    PlaceholderView(colorHex: photo.avgColor, status: .error("default"))
-                                        .frame(maxWidth: .infinity)
-                                        .aspectRatio(CGFloat(photo.width) / CGFloat(photo.height), contentMode: .fit)
-#endif
-                                }
-                            }
-                            .cornerRadius(30)
-                            .onAppear {
-                                if photo == viewModel.photos.last {
-                                    Task {
-                                        await viewModel.loadNextPage()
-                                    }
-                                }
-                            }
+                }
+                .cornerRadius(30)
+                .onAppear {
+                    if photo == viewModel.photos.last {
+                        Task {
+                            await viewModel.loadNextPage()
                         }
                     }
-                    .padding(8)
                 }
             }
-            .refreshable(action: viewModel.didRefresh)
-            //            .navigationTitle("Pexels")
-            .searchable(text: $viewModel.query, prompt: "Search photos...")
         }
-    }
-}
+        .padding(8)
 
-struct PlaceholderView: View {
-    enum Status: Equatable {
-        case loading
-        case error(String)
     }
 
-    var colorHex: String
-    var status: Status
-    @State private var animate = false
-
-    var body: some View {
-        ZStack {
-            switch status {
-            case .loading:
-                ProgressView()
-                    .scaleEffect(1.5)
-            case .error(let error):
-                VStack {
-                    Text("Something went wrong.")
+    var errorBanner: some View {
+        VStack {
+            if let error = viewModel.error {
+                Text("Something went wrong. Please check your internet connection or try again later.")
+                    .padding()
+                    .background(.red.opacity(0.2))
+                    .cornerRadius(20)
 #if DEBUG
-                    Text("Error: \(error)")
+                Text("Error: \(error)")
 #endif
-                }
-                .padding()
             }
-
-            Color(hex: colorHex)
-                .opacity(animate ? 0.2 : 0.4)
-                .animation(
-                    .easeInOut(duration: 1.2)
-                    .repeatForever(autoreverses: true),
-                    value: animate
-                )
-                .onAppear {
-                    if status == .loading {
-                        animate = true
-                    }
-                }
         }
     }
 }

--- a/PexelsClientModules/Sources/UI/PlaceholderView.swift
+++ b/PexelsClientModules/Sources/UI/PlaceholderView.swift
@@ -1,0 +1,51 @@
+import Extensions
+import Foundation
+import SwiftUI
+
+public struct PlaceholderView: View {
+    public enum Status: Equatable {
+        case loading
+        case error(String)
+    }
+
+    public var colorHex: String
+    public var status: Status
+
+    @State private var animate = false
+
+    public init(colorHex: String, status: Status) {
+        self.colorHex = colorHex
+        self.status = status
+    }
+
+    public var body: some View {
+        ZStack {
+            switch status {
+            case .loading:
+                ProgressView()
+                    .scaleEffect(1.5)
+            case .error(let error):
+                VStack {
+                    Text("Something went wrong.")
+#if DEBUG
+                    Text("Error: \(error)")
+#endif
+                }
+                .padding()
+            }
+
+            Color(hex: colorHex)
+                .opacity(animate ? 0.2 : 0.4)
+                .animation(
+                    .easeInOut(duration: 1.2)
+                    .repeatForever(autoreverses: true),
+                    value: animate
+                )
+                .onAppear {
+                    if status == .loading {
+                        animate = true
+                    }
+                }
+        }
+    }
+}

--- a/PexelsClientModules/Sources/UI/ZoomableImageView.swift
+++ b/PexelsClientModules/Sources/UI/ZoomableImageView.swift
@@ -42,11 +42,10 @@ public struct ZoomableImageView: UIViewRepresentable {
         guard let imageView = context.coordinator.imageView else { return }
         if imageView.image == nil {
             DispatchQueue.main.async {
-                print("update1")
                 imageView.image = image
                 imageView.frame = CGRect(origin: .zero, size: image.size)
                 scrollView.contentSize = image.size
-                // After imageView.image is set and scrollView.contentSize = uiImage.size
+
                 let minScale = min(
                     size.width / image.size.width,
                     size.height / image.size.height
@@ -56,7 +55,8 @@ public struct ZoomableImageView: UIViewRepresentable {
                 self.centerImage(in: scrollView, imageView: imageView)
             }
         } else {
-            print("update2")
+            // Called when user rotate screen
+            
             let minScale = min(
                 size.width / image.size.width,
                 size.height / image.size.height

--- a/PexelsClientModules/Sources/UI/ZoomableImageView.swift
+++ b/PexelsClientModules/Sources/UI/ZoomableImageView.swift
@@ -1,0 +1,134 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+public struct ZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+    let size: CGSize
+
+    public init(image: UIImage, size: CGSize) {
+        self.image = image
+        self.size = size
+    }
+
+    public func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 5
+        scrollView.bouncesZoom = true
+        scrollView.alwaysBounceVertical = true
+        scrollView.alwaysBounceHorizontal = true
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.delegate = context.coordinator
+
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        imageView.isUserInteractionEnabled = true
+
+        scrollView.addSubview(imageView)
+        context.coordinator.imageView = imageView
+
+        // Double tap gesture to zoom in/out
+        let doubleTap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleDoubleTap(_:)))
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+
+        return scrollView
+    }
+
+    public func updateUIView(_ scrollView: UIScrollView, context: Context) {
+        guard let imageView = context.coordinator.imageView else { return }
+        if imageView.image == nil {
+            DispatchQueue.main.async {
+                print("update1")
+                imageView.image = image
+                imageView.frame = CGRect(origin: .zero, size: image.size)
+                scrollView.contentSize = image.size
+                // After imageView.image is set and scrollView.contentSize = uiImage.size
+                let minScale = min(
+                    size.width / image.size.width,
+                    size.height / image.size.height
+                )
+                scrollView.minimumZoomScale = minScale
+                scrollView.zoomScale = minScale
+                self.centerImage(in: scrollView, imageView: imageView)
+            }
+        } else {
+            print("update2")
+            let minScale = min(
+                size.width / image.size.width,
+                size.height / image.size.height
+            )
+
+            // Keep the current relative zoom level if the user is zoomed in,
+            // but reset properly if they’re at min scale
+            let wasAtMin = abs(scrollView.zoomScale - scrollView.minimumZoomScale) < 0.01
+            scrollView.minimumZoomScale = minScale
+
+            if wasAtMin {
+                scrollView.zoomScale = minScale
+            }
+
+            self.centerImage(in: scrollView, imageView: imageView)
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    private func centerImage(in scrollView: UIScrollView, imageView: UIImageView) {
+        let scrollSize = size
+        let imageSize = imageView.frame.size
+        let horizontalInset = max(0, (scrollSize.width - imageSize.width) / 2)
+        let verticalInset = max(0, (scrollSize.height - imageSize.height) / 2)
+        scrollView.contentInset = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: 0, right: 0)
+    }
+
+    public class Coordinator: NSObject, UIScrollViewDelegate {
+        var parent: ZoomableImageView
+        weak var imageView: UIImageView?
+
+        init(_ parent: ZoomableImageView) {
+            self.parent = parent
+        }
+
+        public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+
+        public func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            if let imageView = imageView {
+                parent.centerImage(in: scrollView, imageView: imageView)
+            }
+        }
+
+        @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scrollView = gesture.view as? UIScrollView else { return }
+
+            if scrollView.zoomScale > scrollView.minimumZoomScale {
+                // Zoom out
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+            } else {
+                // Zoom in
+                let tapPoint = gesture.location(in: imageView)
+                let fillScale = max(
+                    scrollView.bounds.size.width / (imageView?.bounds.size.width ?? 1),
+                    scrollView.bounds.size.height / (imageView?.bounds.size.height ?? 1)
+                )
+                let newZoomScale = max(fillScale, scrollView.minimumZoomScale)
+
+                let scrollSize = scrollView.bounds.size
+                let width = scrollSize.width / newZoomScale
+                let height = scrollSize.height / newZoomScale
+                let x = tapPoint.x - (width / 2)
+                let y = tapPoint.y - (height / 2)
+
+                let zoomRect = CGRect(x: x, y: y, width: width, height: height)
+                scrollView.zoom(to: zoomRect, animated: true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added initial fullscreen feature
- added match geometry effect for a smooth transition to/from the photos list
- added zoom, drag similar to the iOS Photos app
- added double tap for returning to fit-screen or fill-screen (also similar to Photos app)
- added back and information button with liquid glass
- when information button tapped, info about the photo is displayed (still WIP)